### PR TITLE
chore: rename package to exclude zig as its implied

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -6,7 +6,7 @@ pub fn build(b: *std.build.Builder) void {
     const mode = b.standardReleaseOptions();
     const target = b.standardTargetOptions(.{ .default_target = .{ .cpu_arch = .wasm32, .os_tag = .freestanding } });
 
-    const lib = b.addStaticLibrary("extism-zig-pdk", "src/main.zig");
+    const lib = b.addStaticLibrary("extism-pdk", "src/main.zig");
     lib.setBuildMode(mode);
     lib.addIncludePath("src/");
     lib.install();
@@ -18,11 +18,10 @@ pub fn build(b: *std.build.Builder) void {
     test_step.dependOn(&main_tests.step);
 
     var basic_example = b.addExecutable("Basic example", "examples/basic.zig");
-    basic_example.addPackagePath("extism-zig-pdk", "src/main.zig");
+    basic_example.addPackagePath("extism-pdk", "src/main.zig");
     basic_example.setTarget(target);
     basic_example.setBuildMode(mode);
     basic_example.setOutputDir("examples-out");
-    
 
     const basic_example_step = b.step("basic_example", "Build basic_example");
     basic_example_step.dependOn(&basic_example.step);

--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const zig_pdk = @import("extism-zig-pdk");
+const zig_pdk = @import("extism-pdk");
 const pdk = zig_pdk.Plugin;
 const http = zig_pdk.http;
 
@@ -47,6 +47,6 @@ export fn make_http_request() i32 {
     defer res.deinit();
 
     plugin.outputMemory(res.memory);
-    
+
     return 0;
 }

--- a/gyro.zzz
+++ b/gyro.zzz
@@ -1,5 +1,5 @@
 pkgs:
-  extism-zig-pdk:
+  extism-pdk:
     version: 0.0.1
     description: "Extism Plug-in Development Kit for Zig"
     license: BSD-3-Clause

--- a/zigmod.yml
+++ b/zigmod.yml
@@ -1,5 +1,5 @@
 id: hybfpvr9c5u221hacy3fc4yt4mqorwbcfsz2tuo67um7bafd
-name: extism-zig-pdk
+name: extism-pdk
 main: src/main.zig
 license: BSD-3-Clause
 description: Extism Plug-in Development Kit for Zig


### PR DESCRIPTION
@usdogu - not sure if this will compile (still setting up zig locally), but I would like the package name to be consistent with other PDKs, whereby it excludes the name of the language being used. IMO this is implied since the PDK is specific to a language / ecosystem. We tend to only use the language name in the repo URL (github.com/extism/zig-pdk), and something like `extism-pdk` for the actual package/library itself.