### PR TITLE
feat: use json in basic example, add comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,31 +35,19 @@ jobs:
           pip3 install cffi
           pip3 install .
           popd
-          extism install latest
-
-          extism info
-          curl https://raw.githubusercontent.com/extism/extism/main/wasm/code.wasm > code.wasm
-
-          extism call code.wasm count_vowels --input "this is a test"
-    
+          extism install git
           
       - name: Compile example
         run: |
           zig build basic_example
-          file examples-out/Basic\ example.wasm
+
       - name: Test count_vowels
         run : |
-          TEST=$(extism call examples-out/Basic\ example.wasm --input "this is a test" --set-config='{"thing": "1", "a": "b"}' count_vowels)
+          TEST=$(extism call examples-out/Basic\ example.wasm --input "this is a test" --set-config='{"thing": "1", "a": "b"}' --log-level=debug count_vowels)
           echo $TEST | grep '"count": 4'
           echo $TEST | grep '"config": "1"'
           echo $TEST | grep '"a": "this is var a"'
 
-      - name: Test curl
-        run: | 
-          curl https://jsonplaceholder.typicode.com/todos/1
-
-      - name: Test make_http_request
-        run: |
           TEST=$(extism call examples-out/Basic\ example.wasm make_http_request)
           echo $TEST
           echo $TEST | grep '"userId": 1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           zig build basic_example
 
-      - name: Test count_vowels
+      - name: Test example
         run : |
           TEST=$(extism call examples-out/Basic\ example.wasm --input "this is a test" --set-config='{"thing": "1", "a": "b"}' --log-level=debug count_vowels | jq)
           echo $TEST | grep '"count": 4'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,20 +35,24 @@ jobs:
           pip3 install cffi
           pip3 install .
           popd
-          extism install git
+          extism install latest
       - name: Compile example
         run: |
           zig build basic_example
           
-      - name: Test example
-        run: |
+      - name: Test count_vowels
+        run : |
           TEST=$(extism call examples-out/Basic\ example.wasm --input "this is a test" --set-config='{"thing": "1", "a": "b"}' count_vowels)
           echo $TEST | grep '"count": 4'
           echo $TEST | grep '"config": "1"'
           echo $TEST | grep '"a": "this is var a"'
-        
-          curl https://jsonplaceholder.typicode.com/todos/1 
-          
+
+      - name: Test curl
+        run: | 
+          curl https://jsonplaceholder.typicode.com/todos/1
+
+      - name: Test make_http_request
+        run: |
           TEST=$(extism call examples-out/Basic\ example.wasm make_http_request)
           echo $TEST
           echo $TEST | grep '"userId": 1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Compile example
         run: |
           zig build basic_example
-          
+          file examples-out/Basic\ example.wasm
       - name: Test count_vowels
         run : |
           TEST=$(extism call examples-out/Basic\ example.wasm --input "this is a test" --set-config='{"thing": "1", "a": "b"}' count_vowels)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,13 @@ jobs:
           pip3 install .
           popd
           extism install latest
+
+          extism info
+          curl https://raw.githubusercontent.com/extism/extism/main/wasm/code.wasm > code.wasm
+
+          extism call code.wasm count_vowels --input "this is a test"
+    
+          
       - name: Compile example
         run: |
           zig build basic_example

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,6 @@ jobs:
           repository: extism/cli
           path: cli
 
-      - name: Install Rust (latest stable)
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-
       - name: Install Extism & CLI
         run: |
           pushd cli
@@ -53,4 +47,6 @@ jobs:
           echo $TEST | grep '"config": "1"'
           echo $TEST | grep '"a": "this is var a"'
         
-          extism call examples-out/Basic\ example.wasm make_http_request | grep '"userId": 1'
+          TEST=$(extism call examples-out/Basic\ example.wasm make_http_request)
+          echo $TEST
+          echo $TEST | grep '"userId": 1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,12 @@ jobs:
           repository: extism/cli
           path: cli
 
+      - name: Install Rust (latest stable)
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
       - name: Install Extism & CLI
         run: |
           pushd cli

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Test count_vowels
         run : |
-          TEST=$(extism call examples-out/Basic\ example.wasm --input "this is a test" --set-config='{"thing": "1", "a": "b"}' --log-level=debug count_vowels)
+          TEST=$(extism call examples-out/Basic\ example.wasm --input "this is a test" --set-config='{"thing": "1", "a": "b"}' --log-level=debug count_vowels | jq)
           echo $TEST | grep '"count": 4'
           echo $TEST | grep '"config": "1"'
           echo $TEST | grep '"a": "this is var a"'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
           echo $TEST | grep '"config": "1"'
           echo $TEST | grep '"a": "this is var a"'
         
+          curl https://jsonplaceholder.typicode.com/todos/1 
+          
           TEST=$(extism call examples-out/Basic\ example.wasm make_http_request)
           echo $TEST
           echo $TEST | grep '"userId": 1'

--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -30,6 +30,7 @@ export fn count_vowels() i32 {
     // use persistent variables owned by a plugin instance (stored in-memory between function calls)
     var var_a_optional = plugin.getVar("a") catch unreachable;
     plugin.log(zig_pdk.LogLevel.Debug, "plugin var get");
+
     if (var_a_optional == null) {
         plugin.setVar("a", "this is var a");
         plugin.log(zig_pdk.LogLevel.Debug, "plugin var set");
@@ -42,10 +43,11 @@ export fn count_vowels() i32 {
     // access host-provided configuration (key/value)
     const thing = plugin.getConfig("thing") catch unreachable orelse "<unset by host>";
     plugin.log(zig_pdk.LogLevel.Debug, "plugin config get");
+
     const data = Output{ .count = count, .config = thing, .a = var_a };
     const output = std.json.stringifyAlloc(allocator, data, .{}) catch unreachable;
     defer allocator.free(output);
-    plugin.log(zig_pdk.LogLevel.Debug, "plugin json call");
+    plugin.log(zig_pdk.LogLevel.Debug, "plugin json encoding");
 
     // write the plugin data back to the host
     plugin.output(output);

--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -38,7 +38,8 @@ export fn count_vowels() i32 {
     // access host-provided configuration (key/value)
     const thing = plugin.getConfig("thing") catch unreachable orelse "<unset by host>";
 
-    const output = std.json.stringifyAlloc(allocator, Output{ .count = count, .config = thing, .a = var_a }, .{}) catch unreachable;
+    const data = Output{ .count = count, .config = thing, .a = var_a };
+    const output = std.json.stringifyAlloc(allocator, data, .{}) catch unreachable;
     defer allocator.free(output);
 
     // write the plugin data back to the host

--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -6,6 +6,13 @@ const http = zig_pdk.http;
 pub fn main() void {}
 const allocator = std.heap.wasm_allocator;
 
+// define some type to write as output from the plugin back to the host
+const Output = struct {
+    count: i32,
+    config: []const u8,
+    a: []const u8,
+};
+
 export fn count_vowels() i32 {
     const plugin = pdk.init(allocator);
     const input = plugin.getInput() catch unreachable;
@@ -17,6 +24,8 @@ export fn count_vowels() i32 {
             else => {},
         }
     }
+
+    // use persistent variables owned by a plugin instance (stored in-memory between function calls)
     var var_a_optional = plugin.getVar("a") catch unreachable;
     if (var_a_optional == null) {
         plugin.setVar("a", "this is var a");
@@ -26,11 +35,13 @@ export fn count_vowels() i32 {
     const var_a = plugin.getVar("a") catch unreachable orelse "";
     defer allocator.free(var_a);
 
+    // access host-provided configuration (key/value)
     const thing = plugin.getConfig("thing") catch unreachable orelse "<unset by host>";
 
-    const output = std.fmt.allocPrint(allocator, "{{\"count\": {d}, \"config\": \"{s}\", \"a\": \"{s}\"}}", .{ count, thing, var_a }) catch unreachable;
+    const output = std.json.stringifyAlloc(allocator, Output{ .count = count, .config = thing, .a = var_a }, .{}) catch unreachable;
     defer allocator.free(output);
 
+    // write the plugin data back to the host
     plugin.output(output);
 
     return 0;
@@ -38,14 +49,19 @@ export fn count_vowels() i32 {
 
 export fn make_http_request() i32 {
     const plugin = pdk.init(allocator);
+    // create an HTTP request via Extism built-in function (doesn't require WASI)
     var req = http.HttpRequest.init(allocator, "GET", "https://jsonplaceholder.typicode.com/todos/1");
+    defer req.deinit();
+
+    // set headers on the request object
     req.setHeader("some-name", "some-value") catch unreachable;
     req.setHeader("another", "again") catch unreachable;
 
-    defer req.deinit();
+    // make the request and get the response back
     const res = plugin.request(req) catch unreachable;
     defer res.deinit();
 
+    // `outputMemory` provides a zero-copy way to write plugin data back to the host
     plugin.outputMemory(res.memory);
 
     return 0;

--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -15,8 +15,10 @@ const Output = struct {
 
 export fn count_vowels() i32 {
     const plugin = pdk.init(allocator);
+    plugin.log(zig_pdk.LogLevel.Debug, "plugin start");
     const input = plugin.getInput() catch unreachable;
     defer allocator.free(input);
+    plugin.log(zig_pdk.LogLevel.Debug, "plugin input");
     var count: i32 = 0;
     for (input) |char| {
         switch (char) {
@@ -27,8 +29,10 @@ export fn count_vowels() i32 {
 
     // use persistent variables owned by a plugin instance (stored in-memory between function calls)
     var var_a_optional = plugin.getVar("a") catch unreachable;
+    plugin.log(zig_pdk.LogLevel.Debug, "plugin var get");
     if (var_a_optional == null) {
         plugin.setVar("a", "this is var a");
+        plugin.log(zig_pdk.LogLevel.Debug, "plugin var set");
     } else {
         allocator.free(var_a_optional.?);
     }
@@ -37,13 +41,15 @@ export fn count_vowels() i32 {
 
     // access host-provided configuration (key/value)
     const thing = plugin.getConfig("thing") catch unreachable orelse "<unset by host>";
-
+    plugin.log(zig_pdk.LogLevel.Debug, "plugin config get");
     const data = Output{ .count = count, .config = thing, .a = var_a };
     const output = std.json.stringifyAlloc(allocator, data, .{}) catch unreachable;
     defer allocator.free(output);
+    plugin.log(zig_pdk.LogLevel.Debug, "plugin json call");
 
     // write the plugin data back to the host
     plugin.output(output);
+    plugin.log(zig_pdk.LogLevel.Debug, "plugin output");
 
     return 0;
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -3,7 +3,7 @@ const c = @import("ffi.zig");
 const Memory = @import("memory.zig").Memory;
 pub const http = @import("http.zig");
 
-const LogLevel = enum { Info, Debug, Warn, Error };
+pub const LogLevel = enum { Info, Debug, Warn, Error };
 
 pub const Plugin = struct {
     allocator: std.mem.Allocator,


### PR DESCRIPTION
This PR adds the use of `std.json` in the example plugin. As you, dear reader, may be able to observe.. this lead me down a rabbit hole of debugging :) The simple CI test expected to check for values encoded into the JSON output, and after I changed the plugin code to use the builtin JSON encoder, something changed in the output format and I didn't notice.

Now the test pipes the output to `jq` to normalize the json values and all is right in the world. 