### PR TITLE
fix: add the required paths argument to build.zig.zon

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,5 @@
+.{
+    .name = "extism-pdk",
+    .version = "0.1.0",
+    .paths = .{""},
+}


### PR DESCRIPTION
Closes #18 