### PR TITLE
feat: support reading http response headers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,5 +77,5 @@ jobs:
           COUNT=$(echo $TEST | jq | grep "I'm the inner struct" | wc -l)
           test $COUNT -eq 3
 
-          TEST=$(extism call zig-out/bin/basic-example.wasm http_get --input '' --allow-host jsonplaceholder.typicode.com --enable-http-response-headers --log-level debug 2>&1)
-          echo $TEST | grep "application/json; charset=utf-8"
+          TEST=$(extism call zig-out/bin/basic-example.wasm http_headers --input '' --allow-host github.com --enable-http-response-headers --log-level debug 2>&1)
+          echo $TEST | grep "text/html"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/libextism
+      # - uses: ./.github/actions/libextism
+      - name: Install Extism CLI
+        shell: sh
+        run: sudo curl -s https://get.extism.org/cli | sh -s -- -q -y
+      
+      - name: Check Extism version
+        run: extism --version
 
       - name: Install Zig
         uses: goto-bus-stop/setup-zig@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Install Zig
         uses: goto-bus-stop/setup-zig@v2
+        with:
+          version: 0.13.0
 
       - name: Check Zig Version
         run: zig version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,5 @@ jobs:
           COUNT=$(echo $TEST | jq | grep "I'm the inner struct" | wc -l)
           test $COUNT -eq 3
 
+          TEST=$(extism call zig-out/bin/basic-example.wasm http_get --input '' --allow-host jsonplaceholder.typicode.com --enable-http-response-headers --log-level debug 2>&1)
+          echo $TEST | grep "application/json; charset=utf-8"

--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -135,8 +135,8 @@ export fn http_get() i32 {
         plugin.setError("request failed");
         return @as(i32, res.status);
     }
-    var headers = res.headers(plugin.allocator) catch {
-        plugin.setError("failed to get headers from response!");
+    var headers = res.headers(plugin.allocator) catch |err| {
+        plugin.setErrorFmt("err: {any}, failed to get headers from response!", .{err}) catch unreachable;
         return -1;
     };
     defer headers.deinit();

--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -123,9 +123,9 @@ export fn http_get() i32 {
     var req = http.HttpRequest.init("GET", "https://jsonplaceholder.typicode.com/todos/1");
     defer req.deinit(allocator);
 
-    // set headers on the request object
-    req.setHeader(allocator, "some-name", "some-value") catch unreachable;
-    req.setHeader(allocator, "another", "again") catch unreachable;
+    // // set headers on the request object
+    // req.setHeader(allocator, "some-name", "some-value") catch unreachable;
+    // req.setHeader(allocator, "another", "again") catch unreachable;
 
     // make the request and get the response back
     const res = plugin.request(req, null) catch unreachable;
@@ -135,11 +135,15 @@ export fn http_get() i32 {
         plugin.setError("request failed");
         return @as(i32, res.status);
     }
+    var headers = res.headers(plugin.allocator) catch {
+        plugin.setError("failed to get headers from response!");
+        return -1;
+    };
+    defer headers.deinit();
 
-    const headers = res.headers(allocator) catch unreachable;
     const content_type = headers.get("content-type");
     if (content_type) |t| {
-        plugin.log(.Debug, t);
+        plugin.log(.Debug, t.value); // something like 'application/json; charset=utf-8'
     }
 
     // get the bytes for the res body

--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -136,6 +136,12 @@ export fn http_get() i32 {
         return @as(i32, res.status);
     }
 
+    const headers = res.headers(allocator) catch unreachable;
+    const content_type = headers.get("content-type");
+    if (content_type) |t| {
+        plugin.log(.Debug, t);
+    }
+
     // get the bytes for the res body
     const body = res.body(allocator) catch unreachable;
     // => { "userId": 1, "id": 1, "title": "delectus aut autem", "completed": false }

--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -123,9 +123,9 @@ export fn http_get() i32 {
     var req = http.HttpRequest.init("GET", "https://jsonplaceholder.typicode.com/todos/1");
     defer req.deinit(allocator);
 
-    // // set headers on the request object
-    // req.setHeader(allocator, "some-name", "some-value") catch unreachable;
-    // req.setHeader(allocator, "another", "again") catch unreachable;
+    // set headers on the request object
+    req.setHeader(allocator, "some-name", "some-value") catch unreachable;
+    req.setHeader(allocator, "another", "again") catch unreachable;
 
     // make the request and get the response back
     const res = plugin.request(req, null) catch unreachable;

--- a/src/ffi.zig
+++ b/src/ffi.zig
@@ -17,6 +17,7 @@ pub extern "extism:host/env" fn store_u64(ExtismPointer, u64) void;
 pub extern "extism:host/env" fn load_u64(ExtismPointer) u64;
 pub extern "extism:host/env" fn http_request(ExtismPointer, ExtismPointer) ExtismPointer;
 pub extern "extism:host/env" fn http_status_code() i32;
+pub extern "extism:host/env" fn http_headers() ExtismPointer;
 pub extern "extism:host/env" fn get_log_level() i32;
 pub extern "extism:host/env" fn log_trace(ExtismPointer) void;
 pub extern "extism:host/env" fn log_debug(ExtismPointer) void;

--- a/src/http.zig
+++ b/src/http.zig
@@ -1,5 +1,46 @@
 const std = @import("std");
 const Memory = @import("Memory.zig");
+const extism = @import("ffi.zig");
+
+pub const Headers = struct {
+    allocator: std.mem.Allocator,
+    raw: []const u8,
+    internal: std.json.ArrayHashMap([]const u8),
+
+    /// Get a value (if it exists) from the Headers map at the provided name.
+    /// NOTE: this may be a multi-value header, and will be a comma-separated list.
+    pub fn get(self: Headers, name: []const u8) ?std.http.Header {
+        const val = self.internal.map.get(name);
+        if (val) |v| {
+            return std.http.Header{
+                .name = name,
+                .value = v,
+            };
+        } else {
+            return null;
+        }
+    }
+
+    /// Access the internal data to iterate over or mutate as needed.
+    pub fn internal(self: Headers) std.json.ArrayHashMap([]const u8) {
+        return self.internal;
+    }
+
+    /// Check if the Headers is empty.
+    pub fn isEmpty(self: Headers) bool {
+        return self.internal.map.entries.len == 0;
+    }
+
+    /// Check if a header exists in the Headers.
+    pub fn contains(self: Headers, key: []const u8) bool {
+        return self.internal.map.contains(key);
+    }
+
+    pub fn deinit(self: *Headers) void {
+        self.allocator.free(self.raw);
+        self.internal.deinit(self.allocator);
+    }
+};
 
 pub const HttpResponse = struct {
     memory: Memory,
@@ -23,11 +64,19 @@ pub const HttpResponse = struct {
         return self.status;
     }
 
-    pub fn headers(self: HttpResponse, allocator: std.mem.Allocator) !std.StringArrayHashMap([]u8) {
-        const buf = try allocator.alloc(u8, @intCast(self.responseHeaders.length));
-        self.responseHeaders.load(buf);
-        const out = try std.json.parseFromSlice(std.StringArrayHashMap([]u8), allocator, buf, .{ .allocate = .alloc_always, .ignore_unknown_fields = true });
-        return out.value;
+    /// IMPORTANT: it's the caller's responsibility to `deinit` the Headers if returned.
+    pub fn headers(self: HttpResponse, allocator: std.mem.Allocator) !Headers {
+        const data = try self.responseHeaders.loadAlloc(allocator);
+        errdefer allocator.free(data);
+
+        const j = try std.json.parseFromSlice(std.json.ArrayHashMap([]const u8), allocator, data, .{ .allocate = .alloc_always, .ignore_unknown_fields = true });
+        defer j.deinit();
+
+        return Headers{
+            .allocator = allocator,
+            .raw = data,
+            .internal = j.value,
+        };
     }
 };
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -150,7 +150,6 @@ pub const Plugin = struct {
             .Info => extism.log_info(memory.offset),
             .Warn => extism.log_warn(memory.offset),
             .Error => extism.log_error(memory.offset),
-            .Trace => unreachable, // TODO: trace
         }
     }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -143,12 +143,14 @@ pub const Plugin = struct {
 
     pub fn logMemory(self: Plugin, level: LogLevel, memory: Memory) void {
         _ = self; // to make the interface consistent
+
         switch (level) {
             .Trace => extism.log_trace(memory.offset),
             .Debug => extism.log_debug(memory.offset),
             .Info => extism.log_info(memory.offset),
             .Warn => extism.log_warn(memory.offset),
             .Error => extism.log_error(memory.offset),
+            .Trace => unreachable, // TODO: trace
         }
     }
 
@@ -224,10 +226,15 @@ pub const Plugin = struct {
         const length = extism.length_unsafe(offset);
         const status: u16 = @intCast(extism.http_status_code());
 
+        const headersOffset = extism.http_headers();
+        const headersLength = extism.length(offset);
+        const headersMem = Memory.init(headersOffset, headersLength);
+
         const mem = Memory.init(offset, length);
         return http.HttpResponse{
             .memory = mem,
             .status = status,
+            .responseHeaders = headersMem,
         };
     }
 };

--- a/src/main.zig
+++ b/src/main.zig
@@ -227,7 +227,7 @@ pub const Plugin = struct {
         const status: u16 = @intCast(extism.http_status_code());
 
         const headersOffset = extism.http_headers();
-        const headersLength = extism.length(offset);
+        const headersLength = extism.length_unsafe(headersOffset);
         const headersMem = Memory.init(headersOffset, headersLength);
 
         const mem = Memory.init(offset, length);


### PR DESCRIPTION
Fixes #35 

Note: CI will fail until the a new version of the Extism CLI is released, which provides the necessary `http_headers` import)
